### PR TITLE
Update Jenkinsfile for ubuntu20.04-gnu9.3

### DIFF
--- a/cicd/ubuntu20.04-gnu9.3.Jenkinsfile
+++ b/cicd/ubuntu20.04-gnu9.3.Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 
   environment {
     DOCKER_CREDS = credentials('DockerHubNOAAEPIC')
-    DOCKER_IMAGE_NAME = "${env.JOB_BASE_NAME}"
+    DOCKER_IMAGE_NAME = 'ubuntu20.04-gnu9.3'
     DOCKER_IMAGE_VERSION = '0.1'
     DOCKER_IMAGE_TAG = "${env.DOCKER_CREDS_USR}/${env.DOCKER_IMAGE_NAME}:${env.DOCKER_IMAGE_VERSION}"
   }
@@ -13,7 +13,7 @@ pipeline {
   stages {
     stage('Build') {
       steps {
-        sh 'docker build --tag "${DOCKER_IMAGE_TAG}" --file "${WORKSPACE}/docker/ubuntu20.04-gnu9.3.docker" "${WORKSPACE}"'
+        sh 'docker build --tag "${DOCKER_IMAGE_TAG}" --file "${WORKSPACE}/docker/${DOCKER_IMAGE_NAME}.docker" "${WORKSPACE}"'
       }
     }
 


### PR DESCRIPTION
Hardcode the value for DOCKER_IMAGE_NAME instead of using JOB_BASE_NAME.